### PR TITLE
[fix] Fix NamedEntity::checkName regression

### DIFF
--- a/lib/NamedEntity.cc
+++ b/lib/NamedEntity.cc
@@ -22,7 +22,7 @@
 
 /**
  * Allowed characters for property, namespace, cluster and topic names are
- * alphanumeric (a-zA-Z_0-9) and these special chars -=:.
+ * alphanumeric (a-zA-Z0-9) and these special chars _-=:.
  * @param name
  * @return
  */
@@ -33,6 +33,7 @@ bool NamedEntity::checkName(const std::string& name) {
         }
 
         switch (c) {
+            case '_':
             case '-':
             case '=':
             case ':':

--- a/tests/NamespaceNameTest.cc
+++ b/tests/NamespaceNameTest.cc
@@ -44,9 +44,10 @@ TEST(NamespaceNameTest, testNamespaceNameV2) {
 }
 
 TEST(NamespaceNameTest, testNamespaceNameLegalCharacters) {
-    std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("cluster-1:=.", "namespace-1:=.");
-    ASSERT_EQ("cluster-1:=.", nn1->getProperty());
+    std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("cluster-1:=._", "namespace-1:=._");
+    ASSERT_TRUE(nn1);
+    ASSERT_EQ("cluster-1:=._", nn1->getProperty());
     ASSERT_TRUE(nn1->getCluster().empty());
-    ASSERT_EQ("namespace-1:=.", nn1->getLocalName());
+    ASSERT_EQ("namespace-1:=._", nn1->getLocalName());
     ASSERT_TRUE(nn1->isV2());
 }

--- a/tests/TopicNameTest.cc
+++ b/tests/TopicNameTest.cc
@@ -143,12 +143,13 @@ TEST(TopicNameTest, testIllegalCharacters) {
 }
 
 TEST(TopicNameTest, testLegalNonAlphaCharacters) {
-    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://cluster-1:=./namespace-1:=./topic");
+    std::shared_ptr<TopicName> topicName =
+        TopicName::get("persistent://cluster-1:=._/namespace-1:=._/topic_");
     ASSERT_TRUE(topicName);
-    ASSERT_EQ("cluster-1:=.", topicName->getProperty());
-    ASSERT_EQ("namespace-1:=.", topicName->getNamespacePortion());
+    ASSERT_EQ("cluster-1:=._", topicName->getProperty());
+    ASSERT_EQ("namespace-1:=._", topicName->getNamespacePortion());
     ASSERT_EQ("persistent", topicName->getDomain());
-    ASSERT_EQ("topic", topicName->getLocalName());
+    ASSERT_EQ("topic_", topicName->getLocalName());
 }
 
 TEST(TopicNameTest, testIllegalUrl) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Namspace name with underscore is valid before but now invalid. This regression caused by #52.

Broker validates NamedEntity using regex `"^[-=:.\\w]*$"`, which actually includes the underscore. Although the comment saying `alphanumeric (a-za-z_0-9) and these special characters -=:` is a bit confusing. But we should not break the actual validation rules used a long time ago.

https://github.com/apache/pulsar/blob/355ba6002fc33b2716f59ca5d3a4fac667ecf3e1/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java#L30-L33

### Modifications

<!-- Describe the modifications you've done. -->

Make underscore valid in NamedEntity.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change can covered by existing tests with some modifications, such as NamespaceNameTest.testNamespaceNameLegalCharacters and TopicNameTest.testLegalNonAlphaCharacters.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
fix regression only

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
